### PR TITLE
Maintain Rows and Columns indices order

### DIFF
--- a/ExtractTable/__version__.py
+++ b/ExtractTable/__version__.py
@@ -1,4 +1,4 @@
-VERSION = (2, 0, 0)
+VERSION = (2, 0, 1)
 PRERELEASE = None  # "alpha", "beta" or "rc"
 REVISION = None
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Its up to you now to explore the ways.
 
 # Explore
 check the complete server response of the latest job with `et_sess.ServerResponse.json()`
-```json
+```javascript
 {
     "JobStatus": <string>,                              # Status of the triggered Process  @ JOB-LEVEL
     "Pages": <integer>,                                 # Number of pages processed in this request @ PAGE-LEVEL

--- a/example-code.ipynb
+++ b/example-code.ipynb
@@ -307,7 +307,7 @@
    "source": [
     "> **Understand the output**: The response of a triggered job is a JSON object in the below format. Note that the response depends on the plan type of the API Key.\n",
     "\n",
-    "```json\n",
+    "```javascript\n",
     "{\n",
     "    \"JobStatus\": <string>,                              # Status of the triggered Process  @ JOB-LEVEL\n",
     "    \"Pages\": <integer>,                                 # Number of pages processed in this request @ PAGE-LEVEL\n",


### PR DESCRIPTION
Convert the column and row indices from string to int and sort them by ascending order to be inline with the actual table order